### PR TITLE
Implement two row format in top navigation bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
 *~
-scratch-pad.js
+scratch.*

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -177,21 +177,19 @@ footer {
 
 /* Media Queries for Large Screens
 ------------------------------------------------- */
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 785px) {
       /* hide menu button when displaying on large screens */
       div.to_nav {
         display: none;
     }
 
-
-
-     /* style page navigation at top of screen */
     .container {
         position: relative;
         width: 768px;
         margin: auto;
     }
 
+    /* style page navigation at top of screen */
     #primary_nav {
         position: absolute;
         top: 1px;
@@ -199,17 +197,32 @@ footer {
         background: none;
     }
 
+    #primary_nav ul {
+      margin: 0;
+      margin-top: 15px;
+      padding: 0;
+      overflow: hidden;
+    }
+
     #primary_nav li {
-        display: inline;
+      float: right;
+    }
+
+    #primary_nav li:nth-child(5) {
+      clear: right;
     }
 
     #primary_nav li a {
-        display: inline;
-        border: none;
-        padding: 13px 10px;
-        -webkit-border-radius: 2px;
-        -moz-border-radius: 2px;
-        border-radius: 2px;
+      color: #fff;
+      line-height: 2em;
+      height: 2em;
+      border-bottom: none;
+      padding: 0 10px;
+    }
+
+    #primary_nav li a:hover {
+      color: #cccccc;
+      background: none;
     }
 
     /* hide button for navigating to top when menu is top */
@@ -221,4 +234,24 @@ footer {
     footer {
       margin-top: 2.5rem;
     }
- }
+}
+
+ @media only screen and (min-width: 1170px) {
+
+   #primary_nav {
+     margin-top: 14px;
+   }
+
+   #primary_nav li {
+     display: inline;
+   }
+
+   #primary_nav li:nth-child(5) {
+     float: none;
+   }
+
+   #primary_nav li a {
+     display: inline;
+   }
+
+}


### PR DESCRIPTION
Closes #13 

Whereas previously all links were in a single row in the top navigation
bar for screens larger than 768px, there is now a second stage with two
rows of links for screens larger than 785px. Finally for very large
screens > 1170px there is a one row format.