### PR TITLE
Correct order of navigation menu items

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -223,6 +223,7 @@ footer {
     }
 
     #primary_nav ul {
+      float: right;
       margin: 0;
       margin-top: 1px;
       padding: 0;
@@ -230,11 +231,12 @@ footer {
     }
 
     #primary_nav li {
-      float: right;
+      float: left;
     }
 
     #primary_nav li:nth-child(5) {
-      clear: right;
+      clear: left;
+      margin-left: 173px;
     }
 
     #primary_nav li a {
@@ -269,10 +271,11 @@ footer {
 
    #primary_nav li {
      display: inline;
+     float: none;
    }
 
    #primary_nav li:nth-child(5) {
-     float: none;
+     margin-left: 0;
    }
 
    #primary_nav li a {


### PR DESCRIPTION
Problem of menu items being swapped around was caused by the li elements
in the list of navigation options being floated right (revering the
order).

The trick was to float the enclosing ul element right, with the li items
floated left. Then, a margin-left was given to the 5th element to push
the bottom row to the right, giving it the appearance of being aligned
right.

Closes #18 