### PR TITLE
Remove navigation links to feedback, programme and participants pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,8 +30,13 @@ App.prototype.getViews = function() {
 		res.render('pages/index');
 	})
 
+/*
+Reduced complement of pages for v1.0 of site. To be reinstated when we have
+more info on participants
 	var staticPages = ['background', 'programme', 'registration', 'participants',
 										'location', 'contact', 'feedback'];
+*/
+var staticPages = ['background', 'registration', 'location', 'contact'];
 
 	staticPages.forEach(function(page) {
 		this.app.get('/' + page, function(req, res) {

--- a/views/partials/navigation.ejs
+++ b/views/partials/navigation.ejs
@@ -6,22 +6,13 @@
       <a href="background">Background</a>
     </li>
     <li>
-      <a href="programme">Programme</a>
-    </li>
-    <li>
       <a href="registration">Registration</a>
-    </li>
-    <li>
-      <a href="participants">Participants</a>
     </li>
     <li>
       <a href="location">Location</a>
     </li>
     <li>
       <a href="contact">Contact</a>
-    </li>
-    <li>
-      <a href="feedback">Feedback</a>
     </li>
     <li id="top-button">
       <a href="#home">Top</a>


### PR DESCRIPTION
Also comment out the relevant static pages in app.js so those pages
won't be rendered.

closes #38 